### PR TITLE
/dishes actions + dish link

### DIFF
--- a/app/views/dishes_templates/index.html.erb
+++ b/app/views/dishes_templates/index.html.erb
@@ -89,23 +89,20 @@
       <tr>
         <th>The very best...</th>
         <th>Cuisine</th>
-        <th>Actions</th>
       </tr>
 
       <% @dishes.each do |dish| %>
       <tr>
-        <td><%= dish.name %></td>
+        <td>
+          <a href="/dishes/<%= dish.id %>">
+            <%= dish.name %>
+          </td>
         <td>
           <% if dish.cuisine.present? %>
             <a href="/cuisines/<%= dish.cuisine.id %>">
               <%= dish.cuisine.name %>
             </a>
           <% end %>
-        </td>
-        <td>
-          <a href="/dishes/<%= dish.id %>" class="btn btn-primary">Show</a>
-          <a href="/dishes/<%= dish.id %>/edit" class="btn btn-warning">Edit</a>
-          <a href="/delete_dish/<%= dish.id %>" class="btn btn-danger" rel="nofollow">Delete</a>
         </td>
       </tr>
       <% end %>


### PR DESCRIPTION
On /dishes removed actions header, the actual action buttons (show, edit, delete), and changed the name of the dish to be a hyperlink